### PR TITLE
Update Step 8.

### DIFF
--- a/Azure/Hands-on/azure-resource-manager-rest-api-using-powershell.md
+++ b/Azure/Hands-on/azure-resource-manager-rest-api-using-powershell.md
@@ -140,8 +140,8 @@ $roleJson = @"
   ]
 }
 "@
-Out-File -FilePath ".\$roleName.json" -InputObject $roleJson
-New-AzRoleDefinition -InputFile ".\$roleName.json"
+$roleJson=$roleJson|ConvertFrom-JSON
+New-AzRoleDefinition -Role $roleJson
 ```
 
 **Step 9**: Create a new Azure AD App Registration with a Service Principle. This will also assign the custom role to the Service Principle and set the management scope:


### PR DESCRIPTION
Instead of exporting to a JSON file and then using that to create the role, you can convert the JSON to a PSObject, which is the same format needed for the -role PSObject format.
-Jacob Dyson